### PR TITLE
Square Button & Safety Safe TP fix and TP autosolver fixes

### DIFF
--- a/Assets/Modules/AdvancedButton/AdvancedButton.cs
+++ b/Assets/Modules/AdvancedButton/AdvancedButton.cs
@@ -193,59 +193,13 @@ public class AdvancedButton : FixedTicker
 
         if (batAA == -1)
         {
-            batAA = 0;
-
-            List<string> data = Info.QueryWidgets(KMBombInfo.QUERYKEY_GET_BATTERIES, null);
-            foreach (string response in data) {
-                Dictionary<string, int> responseDict = JsonConvert.DeserializeObject<Dictionary<string, int>>(response);
-                if (responseDict["numbatteries"] == 1) batD++;
-                else batAA += responseDict["numbatteries"];
-            }
-            data = Info.QueryWidgets(KMBombInfo.QUERYKEY_GET_INDICATOR, null);
-            foreach (string response in data)
-            {
-                Dictionary<string, bool> responseDict = JsonConvert.DeserializeObject<Dictionary<string, bool>>(response, new JsonSerializerSettings
-                {
-                    Error = HandleError
-                });
-                if (responseDict["on"]) litInd++;
-                else unlitInd++;
-            }
-            data = Info.QueryWidgets(KMBombInfo.QUERYKEY_GET_SERIAL_NUMBER, null);
-            foreach (string response in data)
-            {
-                Dictionary<string, string> responseDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(response);
-                string serial = responseDict["serial"];
-                if (serial.Contains("A") || serial.Contains("E") || serial.Contains("I") || serial.Contains("O") || serial.Contains("U")) serialVowel = true;
-
-                if (serial.Contains("9")) highSerial = 9;
-                else if (serial.Contains("8")) highSerial = 8;
-                else if (serial.Contains("7")) highSerial = 7;
-                else if (serial.Contains("6")) highSerial = 6;
-                else if (serial.Contains("5")) highSerial = 5;
-                else if (serial.Contains("4")) highSerial = 4;
-                else if (serial.Contains("3")) highSerial = 3;
-                else if (serial.Contains("2")) highSerial = 2;
-                else if (serial.Contains("1")) highSerial = 1;
-            }
+            GetEdgeworkAndRule();
 
             Debug.Log("[Square Button #"+thisLoggingID+"] Batteries: " + batAA + "AA, " + batD + "D");
             Debug.Log("[Square Button #"+thisLoggingID+"] Highest serial number: " + highSerial);
             Debug.Log("[Square Button #"+thisLoggingID+"] Serial contains a vowel: " + serialVowel);
             Debug.Log("[Square Button #"+thisLoggingID+"] Button colour: " + colourNames[buttonCol]);
             Debug.Log("[Square Button #"+thisLoggingID+"] Button text: " + "\"" + buttonLabels[buttonText] + "\" " + buttonText);
-
-            if (buttonCol == 1 && batAA > batD) hold = true;
-            else if ((buttonCol < 2) && buttonLabels[buttonText].Length >= highSerial) hold = false;
-            else if (buttonCol < 2 && buttonText < 4) hold = true;
-            else if (buttonLabels[buttonText].Length == 0)
-            {
-                hold = false;
-                catch22 = true;
-            }
-            else if (buttonCol != 3 && buttonLabels[buttonText].Length > litInd) hold = false;
-            else if (unlitInd >= 2 && serialVowel) hold = false;
-            else hold = true;
 
             Debug.Log("[Square Button #"+thisLoggingID+"] Hold: " + hold);
             if (!hold) Debug.Log("[Square Button #"+thisLoggingID+"] Release and Match: " + catch22);
@@ -356,18 +310,159 @@ public class AdvancedButton : FixedTicker
         return;
     }
 
+    protected void GetEdgeworkAndRule()
+    {
+        batAA = 0;
+
+        List<string> data = Info.QueryWidgets(KMBombInfo.QUERYKEY_GET_BATTERIES, null);
+        foreach (string response in data)
+        {
+            Dictionary<string, int> responseDict = JsonConvert.DeserializeObject<Dictionary<string, int>>(response);
+            if (responseDict["numbatteries"] == 1) batD++;
+            else batAA += responseDict["numbatteries"];
+        }
+        data = Info.QueryWidgets(KMBombInfo.QUERYKEY_GET_INDICATOR, null);
+        foreach (string response in data)
+        {
+            Dictionary<string, bool> responseDict = JsonConvert.DeserializeObject<Dictionary<string, bool>>(response, new JsonSerializerSettings
+            {
+                Error = HandleError
+            });
+            if (responseDict["on"]) litInd++;
+            else unlitInd++;
+        }
+        data = Info.QueryWidgets(KMBombInfo.QUERYKEY_GET_SERIAL_NUMBER, null);
+        foreach (string response in data)
+        {
+            Dictionary<string, string> responseDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(response);
+            string serial = responseDict["serial"];
+            if (serial.Contains("A") || serial.Contains("E") || serial.Contains("I") || serial.Contains("O") || serial.Contains("U")) serialVowel = true;
+
+            if (serial.Contains("9")) highSerial = 9;
+            else if (serial.Contains("8")) highSerial = 8;
+            else if (serial.Contains("7")) highSerial = 7;
+            else if (serial.Contains("6")) highSerial = 6;
+            else if (serial.Contains("5")) highSerial = 5;
+            else if (serial.Contains("4")) highSerial = 4;
+            else if (serial.Contains("3")) highSerial = 3;
+            else if (serial.Contains("2")) highSerial = 2;
+            else if (serial.Contains("1")) highSerial = 1;
+        }
+
+        if (buttonCol == 1 && batAA > batD) hold = true;
+        else if ((buttonCol < 2) && buttonLabels[buttonText].Length >= highSerial) hold = false;
+        else if (buttonCol < 2 && buttonText < 4) hold = true;
+        else if (buttonLabels[buttonText].Length == 0)
+        {
+            hold = false;
+            catch22 = true;
+        }
+        else if (buttonCol != 3 && buttonLabels[buttonText].Length > litInd) hold = false;
+        else if (unlitInd >= 2 && serialVowel) hold = false;
+        else hold = true;
+    }
+
     //Twitch Plays support
 
     #pragma warning disable 0414
     bool TwitchZenMode = false;
-    string TwitchHelpMessage = "Hold the button down with 'hold', or press and release with 'press' or 'tap'.\nIf you want to press and release at a specific time, use 'press <time>'.\nRelease the button with 'release <time> <time> ...'.\nTimes are specified as either '23, 35, 40' (seconds only), or '1:40 1:47 1:54' (full timer), but cannot be mixed.\nRaise the molly guard and examine the button with 'view'.";
+    string TwitchHelpMessage = "Hold the button down with 'hold', or press and release with 'press' or 'tap'.\nIf you want to press and release at a specific time, use 'press <time>'.\nRelease the button with 'release <time> <time> ...'.\nTimes are specified as either '23, 35, 40' (seconds only), or '1:40 1:47 1:54' (full timer), but cannot be mixed.\nRaise the molly guard and examine the button with 'show'.";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
-        buttonDown = false;
-        Button.transform.localPosition = new Vector3(0, 0, 0);
-        Debug.Log("[Square Button #"+thisLoggingID+"] Module forcibly solved.");
-        GetComponent<KMBombModule>().HandlePass();
+    public IEnumerator TwitchHandleForcedSolve() {
+        Debug.Log("[Square Button #" + thisLoggingID + "] Module forcibly solved.");
+        if (batAA == -1)
+            GetEdgeworkAndRule();
+        if ((!hold && buttonDown && ticker >= 0) || (buttonDown && ticker < 0 && catch22 && (int)(Info.GetTime() % 60 % 11) != 0))
+        {
+            //Force the solve since the module would strike otherwise
+            buttonDown = false;
+            Light.material.color = BLACK;
+            Button.transform.localPosition = new Vector3(0, 0, 0);
+            GetComponent<KMBombModule>().HandlePass();
+            yield break;
+        }
+        else if (!hold)
+        {
+            if (catch22)
+            {
+                while ((int)(Info.GetTime() % 60 % 11) != 0) yield return true;
+                if (!buttonDown)
+                {
+                    Button.OnInteract();
+                    if ((!TwitchZenMode && (int)(Info.GetTime() - 0.05f) == (int)Info.GetTime()) || (TwitchZenMode && (int)(Info.GetTime() + 0.05f) == (int)Info.GetTime()))
+                        yield return new WaitForSeconds(0.05f);
+                }
+                Button.OnInteractEnded();
+            }
+            else
+            {
+                if (!buttonDown)
+                {
+                    Button.OnInteract();
+                    yield return new WaitForSeconds(0.05f);
+                }
+                Button.OnInteractEnded();
+            }
+        }
+        else
+        {
+            if (!buttonDown)
+                Button.OnInteract();
+            while (ticker < 0) yield return true;
+            if (!flashing)
+            {
+                while (true)
+                {
+                    int time = (int)Info.GetTime();
+                    time %= 60;
+                    time = (time / 10) + (time % 10);
+                    if (time > 10) time -= 10;
+                    if (holdColour == 0)
+                    {
+                        if (time == 7) break;
+                    }
+                    else if (holdColour == 1)
+                    {
+                        if (time == 3) break;
+                    }
+                    else
+                    {
+                        if (time == 5) break;
+                    }
+                    yield return true;
+                }
+            }
+            else
+            {
+                while (true)
+                {
+                    int time = (int)Info.GetTime();
+                    if (holdColour == 0)
+                    {
+                        if (time % 7 == 0) break;
+                    }
+                    else if (holdColour == 1)
+                    {
+                        time %= 60;
+                        if (time == 0 || time == 2 || time == 3 || time == 5 ||
+                            time == 7 || time == 11 || time == 13 || time == 17 ||
+                            time == 19 || time == 23 || time == 29 || time == 31 ||
+                            time == 37 || time == 41 || time == 43 || time == 47 ||
+                            time == 53 || time == 59) break;
+                    }
+                    else
+                    {
+                        time++;
+                        time %= 60;
+                        time = (time / 10) + (time % 10);
+                        if (time % 4 == 0) break;
+                    }
+                    yield return true;
+                }
+            }
+            Button.OnInteractEnded();
+        }
     }
 
     public IEnumerator ProcessTwitchCommand(string cmd) {
@@ -429,7 +524,8 @@ public class AdvancedButton : FixedTicker
             while(releaseCoroutine.MoveNext()) {
                 yield return releaseCoroutine.Current;
             }
-            yield return new WaitForSeconds(0.05f);
+            if ((!TwitchZenMode && (int)(Info.GetTime() - 0.05f) == (int)Info.GetTime()) || (TwitchZenMode && (int)(Info.GetTime() + 0.05f) == (int)Info.GetTime()))
+                yield return new WaitForSeconds(0.05f);
             yield return Button;
             yield break;
         }

--- a/Assets/Modules/AdvancedKeypad/AdvancedKeypad.cs
+++ b/Assets/Modules/AdvancedKeypad/AdvancedKeypad.cs
@@ -184,11 +184,14 @@ public class AdvancedKeypad : MonoBehaviour
     string TwitchHelpMessage = "Submit a solution using 'press 1 4 2...'. You can use either numbers starting with 1 at the top going clockwise (1 through 8), or compass directions (N, NE, E, etc.).";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
+    public IEnumerator TwitchHandleForcedSolve() {
         Debug.Log("[Round Keypad #"+thisLoggingID+"] Module forcibly solved.");
         for(int a = 0; a < ButtonStates.Length; a++) {
             if(ButtonStates[a]) continue;
-            if(Solution[a]) Guess(a);
+            if(Solution[a]) { 
+                Buttons[a].OnInteract();
+                yield return new WaitForSeconds(0.25f);
+            }
         }
     }
 

--- a/Assets/Modules/AdvancedMaze/AdvancedMaze.cs
+++ b/Assets/Modules/AdvancedMaze/AdvancedMaze.cs
@@ -1560,18 +1560,17 @@ public class AdvancedMaze : MonoBehaviour
     string TwitchHelpMessage = "Rotate pipes using 'rotate A3 B4 B2 ...'. Submit answer using 'submit'. Pipe positions use battleship notation, letters are A-F left to right and numbers are 1-6 top to bottom.";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
+    public IEnumerator TwitchHandleForcedSolve() {
         Debug.Log("[Plumbing #"+thisLoggingID+"] Module forcibly solved.");
 
-        StartCoroutine(Solver());
-    }
-
-    private IEnumerator Solver() {
         SetMergedMode(false);
-        for(int x = 0; x < 6; x++) {
-            for(int y = 0; y < 6; y++) {
-                while(SolutionState[x][y] != PlayFieldState[x][y]) {
-                    HandleInteract(x, y);
+        for (int x = 0; x < 6; x++)
+        {
+            for (int y = 0; y < 6; y++)
+            {
+                while (SolutionState[x][y] != PlayFieldState[x][y])
+                {
+                    Buttons[x][y].OnInteract();
                     yield return new WaitForSeconds(0.05f);
                 }
             }

--- a/Assets/Modules/AdvancedMemory/AdvancedMemory.cs
+++ b/Assets/Modules/AdvancedMemory/AdvancedMemory.cs
@@ -39,8 +39,6 @@ public class AdvancedMemory : MonoBehaviour
     private int[] Solution;
     private int Position;
 
-    private bool forcedSolve = false;
-
     void Awake()
     {
         if (ignoredModules == null)
@@ -281,7 +279,7 @@ public class AdvancedMemory : MonoBehaviour
         Debug.Log("[Forget Me Not #"+thisLoggingID+"] Solution: " + solutionText);
 
         if(PERFORM_AUTO_SOLVE) {
-            TwitchHandleForcedSolve();
+            StartCoroutine(TwitchHandleForcedSolve());
         }
     }
 
@@ -292,8 +290,6 @@ public class AdvancedMemory : MonoBehaviour
     int displayCurStage = 0;
     void FixedUpdate()
     {
-        if(forcedSolve) return;
-
         if(displayTimer > 0) displayTimer -= Time.fixedDeltaTime;
 
         ticker++;
@@ -344,7 +340,7 @@ public class AdvancedMemory : MonoBehaviour
         if (Solution == null || Position >= Solution.Length) return false;
 
         int progress = BombInfo.GetSolvedModuleNames().Where(x => !ignoredModules.Contains(x)).Count() + ADDED_STAGES;
-        if (progress < Solution.Length && !forcedSolve) {
+        if (progress < Solution.Length) {
             Debug.Log("[Forget Me Not #"+thisLoggingID+"] Tried to enter a value before solving all other modules.");
             GetComponent<KMBombModule>().HandleStrike();
             return false;
@@ -550,16 +546,13 @@ public class AdvancedMemory : MonoBehaviour
     string TwitchHelpMessage = "Enter the Forget Me Not sequence with \"!{0} press 531820...\". The sequence length depends on how many modules were on the bomb. You may use spaces and commas in the digit sequence.";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
+    public IEnumerator TwitchHandleForcedSolve() {
         Debug.Log("[Forget Me Not #"+thisLoggingID+"] Module forcibly solved.");
-        forcedSolve = true;
-        StartCoroutine(Solver());
-    }
-
-    private IEnumerator Solver() {
-        while(Position < Solution.Length) {
+        while (!done) yield return true; //Waits for all other mods on the bomb to be solved, if FMN needs to be solved right away, executing the solve command again will do this
+        while (Position < Solution.Length)
+        {
+            Buttons[Solution[Position]].OnInteract();
             yield return new WaitForSeconds(0.05f);
-            Handle(Solution[Position]);
         }
     }
 

--- a/Assets/Modules/AdvancedMorse/AdvancedMorse.cs
+++ b/Assets/Modules/AdvancedMorse/AdvancedMorse.cs
@@ -935,19 +935,28 @@ public class AdvancedMorse : FixedTicker
     string TwitchHelpMessage = "Submit a solution using 'submit ..-.'. Toggle the lights using 'toggle'. If there is considerable lag, use 'submitlag ..-.' instead.";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
+    public IEnumerator TwitchHandleForcedSolve() {
         Debug.Log("[Morsematics #"+thisLoggingID+"] Module forcibly solved.");
-        StartCoroutine(Solver());
-    }
-
-    private IEnumerator Solver() {
-        foreach(int i in Morsify(Answer)) {
+        if (transmitTicker >= 0)
+        {
+            //Force the solve since the module could strike otherwise
+            StopAllCoroutines();
+            solved = true;
+            Draw.Clear();
+            LED.materials[1].color = LED_OFF;
+            LED.materials[2].color = LED_OFF;
+            LED.materials[3].color = LED_OFF;
+            GetComponent<KMBombModule>().HandlePass();
+        }
+        foreach (int i in Morsify(Answer))
+        {
             ButtonTransmit.OnInteract();
-            if(i == 1) yield return new WaitForSeconds(0.6f);
+            if (i == 1) yield return new WaitForSeconds(0.6f);
             else yield return new WaitForSeconds(0.2f);
             ButtonTransmit.OnInteractEnded();
             yield return new WaitForSeconds(0.2f);
         }
+        while (!solved) yield return true;
     }
 
     public IEnumerator ProcessTwitchCommand(string cmd) {

--- a/Assets/Modules/AdvancedPassword/AdvancedPassword.cs
+++ b/Assets/Modules/AdvancedPassword/AdvancedPassword.cs
@@ -402,6 +402,16 @@ public class AdvancedPassword : MonoBehaviour
                     yield return "sendtochaterror Unknown dial: " + command[0];
                     yield break;
                 }
+                if (!int.TryParse(command[1], out temp))
+                {
+                    yield return "sendtochaterror Invalid number: " + command[1];
+                    yield break;
+                }
+                if (temp < 0)
+                {
+                    yield return "sendtochaterror Invalid number: " + command[1];
+                    yield break;
+                }
                 int amt = int.Parse(command[1]) % 12;
                 if(amt < 0) amt += 12;
                 
@@ -419,6 +429,16 @@ public class AdvancedPassword : MonoBehaviour
                         yield return "sendtochaterror Unknown dial: " + command[0];
                         yield break;
                     }
+                    if (!int.TryParse(command[2], out temp))
+                    {
+                        yield return "sendtochaterror Invalid number: " + command[2];
+                        yield break;
+                    }
+                    if (temp < 0)
+                    {
+                        yield return "sendtochaterror Invalid number: " + command[2];
+                        yield break;
+                    }
                     int amt = int.Parse(command[2]) % 12;
                     if(amt < 0) amt += 12;
                 
@@ -434,6 +454,16 @@ public class AdvancedPassword : MonoBehaviour
                 if(command[0].Equals("press") || command[0].Equals("cycle") || command[0].Equals("submit") || command[0].Equals("guess")) {
                     int[] amt = new int[6];
                     for(int a = 0; a < 6; a++) {
+                        if (!int.TryParse(command[a+1], out temp))
+                        {
+                            yield return "sendtochaterror Invalid number: " + command[a+1];
+                            yield break;
+                        }
+                        if (temp < 0)
+                        {
+                            yield return "sendtochaterror Invalid number: " + command[a+1];
+                            yield break;
+                        }
                         amt[a] = int.Parse(command[a+1]) % 12;
                         if(amt[a] < 0) amt[a] += 12;
                     }
@@ -458,6 +488,16 @@ public class AdvancedPassword : MonoBehaviour
             amt[0] = temp % 12;
             if(amt[0] < 0) amt[0] += 12;
             for(int a = 0; a < 6; a++) {
+                if (!int.TryParse(command[a], out temp))
+                {
+                    yield return "sendtochaterror Invalid number: " + command[a];
+                    yield break;
+                }
+                if (temp < 0)
+                {
+                    yield return "sendtochaterror Invalid number: " + command[a];
+                    yield break;
+                }
                 amt[a] = int.Parse(command[a]) % 12;
                 if(amt[a] < 0) amt[a] += 12;
             }

--- a/Assets/Modules/AdvancedPassword/AdvancedPassword.cs
+++ b/Assets/Modules/AdvancedPassword/AdvancedPassword.cs
@@ -311,20 +311,17 @@ public class AdvancedPassword : MonoBehaviour
     string TwitchHelpMessage = "Cycle a dial with 'press TL 6'. Cycle all dials with 'press 1 8 2 12 0 5'. Listen to dials with 'listen' or 'listen BR'. Submit an answer with 'submit'.\nDial positions are specified with positions (TL, TM, TR, BL, BM, BR).";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
+    public IEnumerator TwitchHandleForcedSolve() {
         Debug.Log("[Safety Safe #"+thisLoggingID+"] Module forcibly solved.");
-        StartCoroutine(Solver());
-    }
-
-    private IEnumerator Solver() {
-        for(int a = 0; a < 6; a++) {
-            while(DialPos[a] != AnswerPos[a]) {
-                HandleInteract(a);
+        for (int a = 0; a < 6; a++)
+        {
+            while (DialPos[a] != AnswerPos[a])
+            {
+                Dials[a].OnInteract();
                 yield return new WaitForSeconds(0.05f);
             }
         }
-        HandleLever();
-        yield break;
+        Lever.OnInteract();
     }
 
     private int ParseDial(string dial) {

--- a/Assets/Modules/AdvancedSimon/AdvancedSimon.cs
+++ b/Assets/Modules/AdvancedSimon/AdvancedSimon.cs
@@ -660,17 +660,14 @@ public class AdvancedSimon : FixedTicker
     string TwitchHelpMessage = "Press buttons with 'press RYB'.";
     #pragma warning restore 0414
 
-    public void TwitchHandleForcedSolve() {
+    public IEnumerator TwitchHandleForcedSolve() {
         Debug.Log("[Simon States #"+thisLoggingID+"] Module forcibly solved.");
-        StartCoroutine(Solver());
-    }
-
-    private IEnumerator Solver() {
-        while(PuzzleDisplay != null) {
-            Handle(Answer[SubProgress]);
-            yield return new WaitForSeconds(bop?0.4f:0.29f);
+        List<KMSelectable> buttons = new List<KMSelectable>() { ButtonRed, ButtonYellow, ButtonGreen, ButtonBlue };
+        while (PuzzleDisplay != null)
+        {
+            buttons[Answer[SubProgress]].OnInteract();
+            yield return new WaitForSeconds(bop ? 0.4f : 0.29f);
         }
-        yield break;
     }
     
     private bool bop = false;


### PR DESCRIPTION
- Fixed Square Button TP on a 'press' or 'tap' command that is timed very rarely releasing the button one second after the time that was specified in the command
- Fixed Safety Safe throwing exceptions on TP if an inputted number is too large or negative
- Changed all TP autosolvers from void methods to IEnumerators so they are then included in the solve queue with other modules and not just solved immediately
- Changed FMN's autosolver significantly, it will now wait for all other mods to be solved and then input the sequence (it can be forced into a solved state if needed by using the solve command again)